### PR TITLE
Refactor file download logic to set the filename for downloaded files

### DIFF
--- a/digital_subscriptions/digital_subscriptions/doctype/file_version/file_version.py
+++ b/digital_subscriptions/digital_subscriptions/doctype/file_version/file_version.py
@@ -59,14 +59,8 @@ def send_private_file(path: str) -> Response:
 
 		response = Response(wrap_file(frappe.local.request.environ, f), direct_passthrough=True)
 
-	# no need for content disposition and force download. let browser handle its opening.
-	# Except for those that can be injected with scripts.
-
-	extension = os.path.splitext(path)[1]
-	blacklist = [".svg", ".html", ".htm", ".xml"]
-
-	if extension.lower() in blacklist:
-		response.headers.add("Content-Disposition", "attachment", filename=filename)
+	# Set the filename for the downloaded file
+	response.headers.add("Content-Disposition", "attachment", filename=filename)
 
 	response.mimetype = mimetypes.guess_type(filename)[0] or "application/octet-stream"
 


### PR DESCRIPTION
This pull request refactors the file download logic to set the filename for downloaded files. Previously, the logic relied on the browser to handle the opening of certain file types, but now the filename is explicitly set in the response headers. This ensures consistent behavior across different browsers and improves the user experience when downloading files.